### PR TITLE
Fix: screen dimming during idle/lock problems

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -283,14 +283,30 @@ brightness)
 			bash "${SCRIPT_DIR}/scripts/brightness_list.sh" >"${BRIGHTNESS_SAVE_FILE}.tmp" 2>/dev/null || {
 				echo "Warning: Could not query current brightness"
 			}
+			# Skip saving if brightness is 0 (screen off state) and we already have a save
 			if [ -f "${BRIGHTNESS_SAVE_FILE}.tmp" ]; then
-				while IFS=: read -r name bright method; do
-					if [ -n "$name" ] && [ -n "$bright" ]; then
-						echo "${name}:${bright}"
+				# Check if all values are 0 or very low (screen off state)
+				ALL_ZERO=true
+				while IFS=: read -r name bright; do
+					if [ -n "$bright" ] && [ "$bright" -gt 5 ]; then
+						ALL_ZERO=false
+						break
 					fi
-				done <"${BRIGHTNESS_SAVE_FILE}.tmp" >"$BRIGHTNESS_SAVE_FILE"
-				rm -f "${BRIGHTNESS_SAVE_FILE}.tmp"
-				echo "Saved current brightness for all monitors"
+				done <"${BRIGHTNESS_SAVE_FILE}.tmp"
+				
+				# Only save if not all zero, OR if no previous save exists
+				if [ "$ALL_ZERO" = true ] && [ -f "$BRIGHTNESS_SAVE_FILE" ]; then
+					echo "Skipped saving - brightness at 0 (keeping previous save)"
+					rm -f "${BRIGHTNESS_SAVE_FILE}.tmp"
+				else
+					while IFS=: read -r name bright; do
+						if [ -n "$name" ] && [ -n "$bright" ]; then
+							echo "${name}:${bright}"
+						fi
+					done <"${BRIGHTNESS_SAVE_FILE}.tmp" >"$BRIGHTNESS_SAVE_FILE"
+					rm -f "${BRIGHTNESS_SAVE_FILE}.tmp"
+					echo "Saved current brightness for all monitors"
+				fi
 			fi
 		else
 			# Save specific monitor
@@ -352,14 +368,30 @@ brightness)
 				echo "Warning: Could not query current brightness"
 			}
 			# Convert format from name:brightness:method to name:brightness
+			# Skip saving if brightness is 0 (screen off state) and we already have a save
 			if [ -f "${BRIGHTNESS_SAVE_FILE}.tmp" ]; then
-				while IFS=: read -r name bright method; do
-					if [ -n "$name" ] && [ -n "$bright" ]; then
-						echo "${name}:${bright}"
+				# Check if all values are 0 or very low (screen off state)
+				ALL_ZERO=true
+				while IFS=: read -r name bright; do
+					if [ -n "$bright" ] && [ "$bright" -gt 5 ]; then
+						ALL_ZERO=false
+						break
 					fi
-				done <"${BRIGHTNESS_SAVE_FILE}.tmp" >"$BRIGHTNESS_SAVE_FILE"
-				rm -f "${BRIGHTNESS_SAVE_FILE}.tmp"
-				echo "Saved current brightness for all monitors"
+				done <"${BRIGHTNESS_SAVE_FILE}.tmp"
+				
+				# Only save if not all zero, OR if no previous save exists
+				if [ "$ALL_ZERO" = true ] && [ -f "$BRIGHTNESS_SAVE_FILE" ]; then
+					echo "Skipped saving - brightness at 0 (keeping previous save)"
+					rm -f "${BRIGHTNESS_SAVE_FILE}.tmp"
+				else
+					while IFS=: read -r name bright; do
+						if [ -n "$name" ] && [ -n "$bright" ]; then
+							echo "${name}:${bright}"
+						fi
+					done <"${BRIGHTNESS_SAVE_FILE}.tmp" >"$BRIGHTNESS_SAVE_FILE"
+					rm -f "${BRIGHTNESS_SAVE_FILE}.tmp"
+					echo "Saved current brightness for all monitors"
+				fi
 			fi
 		else
 			# Save specific monitor

--- a/modules/services/IdleService.qml
+++ b/modules/services/IdleService.qml
@@ -6,6 +6,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import qs.config
+import qs.modules.services
 
 Singleton {
     id: root
@@ -110,6 +111,12 @@ Singleton {
     }
 
     function checkListeners() {
+        // Skip idle actions if media is playing (YouTube, Spotify, etc.)
+        if (MprisController.isPlaying) {
+            root.elapsedIdleTime = 0; // Reset timer while media plays
+            return;
+        }
+        
         let listeners = Config.system.idle.listeners;
         for (let i = 0; i < listeners.length; i++) {
             let listener = listeners[i];


### PR DESCRIPTION
# Related https://github.com/Axenide/Ambxst/issues/29

### What changed?
- Skip saving brightness if value is <= 5% and save file already exists (prevents overwriting correct value with screen-off state)
- Add 1.5s cooldown after listener triggers to prevent immediate resume from lockscreen activity, defer reset if activity occurs during cooldown
- Skip idle listener triggers when `MprisController.isPlaying` is true
- Reset elapsed idle time while media plays
- Prevents screen dimming/lock while watching Youtube, Spotify, etc.

> [!IMPORTANT]
> - **Didn't test on multi monitors because I don't have**
> - **Need test on multi monitors**
> - I have caculated to set `interval: 1500`, it is enough for lock screen to fully load, I tested on 500ms, it will return default brightness immediately after the screen locked. If it is more than 1.5s, we will see a small delay to return default brightness after moving our mouse. It means, after the screen is locked and the screen is at 0% brightness, if we press keyboard, it willl return your default brightness, but it needs a small delay to return after moving out mouse, this will make a really bad user experience

> [!NOTE]
> Tested on Zen (Firefox based), tested on Brave (Chromium based) with Youtube
> This PR is from latest commit of upstream dev branch ae54c8e12f9f1904ce6db966b6ff0398193d65e9