### PR TITLE
Update PowerProfileSelector.qml

### DIFF
--- a/modules/bar/PowerProfileSelector.qml
+++ b/modules/bar/PowerProfileSelector.qml
@@ -141,7 +141,7 @@ StyledRect {
                         text: PowerProfile.getProfileIcon(modelData)
                         color: PowerProfile.currentProfile === modelData ? Styling.srItem("primary") : Colors.overBackground
                         font.family: Icons.font
-                        font.pixelSize: 18
+                        font.pixelSize: 15 
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
 


### PR DESCRIPTION
Hi @Axenide, hope you're doing well. I changed the font size in powerProfileSelector to lower size because the fonts **doesn't show** well in 18, so I changed that  to 15

---
<img width="354" height="165" alt="image" src="https://github.com/user-attachments/assets/3a53f139-7faf-46b3-b270-128c0c716750" />

---

Now those fonts fits well :)