### PR TITLE
feat: overview behaviour for tab and shifttab

### DIFF
--- a/modules/widgets/overview/OverviewPopup.qml
+++ b/modules/widgets/overview/OverviewPopup.qml
@@ -250,7 +250,13 @@ PanelWindow {
 
                     onLeftPressed: {
                         if (searchInput.text.length === 0) {
-                            Hyprland.dispatch("workspace r-1");
+                            const current = Hyprland.focusedWorkspace?.id || 1;
+                            const prev = current - 1;
+                            if (prev < 1) {
+                                Hyprland.dispatch("workspace " + Config.workspaces.shown);
+                            } else {
+                                Hyprland.dispatch("workspace r-1");
+                            }
                         } else if (overviewLoader.item) {
                             overviewLoader.item.selectPrevMatch();
                         }
@@ -258,7 +264,13 @@ PanelWindow {
 
                     onRightPressed: {
                         if (searchInput.text.length === 0) {
-                            Hyprland.dispatch("workspace r+1");
+                            const current = Hyprland.focusedWorkspace?.id || 1;
+                            const next = current + 1;
+                            if (next > Config.workspaces.shown) {
+                                Hyprland.dispatch("workspace 1");
+                            } else {
+                                Hyprland.dispatch("workspace r+1");
+                            }
                         } else if (overviewLoader.item) {
                             overviewLoader.item.selectNextMatch();
                         }


### PR DESCRIPTION
[<>0a5017d](https://github.com/Axenide/Ambxst/tree/0a5017d2d88570316eb24226c0a8ebf610a0d6bc) implements rough scrolling with tab and shifttab

[<>1066a76](https://github.com/Axenide/Ambxst/tree/1066a76f29e006310941e0623df9512b2f1ec11c) uses Config.workspaces.shown to determine how much workspaces the user sets in the qs config and prevents excessive scrolling

[<>6b5d7a3](https://github.com/Axenide/Ambxst/tree/6b5d7a30b10214ab3fe5c7a1caaefce497867383) implements the same changes for left and right arrow

loving ambxst so far :)