### PR TITLE
Improve battery popup layout and power profile buttons

### DIFF
--- a/modules/bar/BatteryIndicator.qml
+++ b/modules/bar/BatteryIndicator.qml
@@ -327,7 +327,7 @@ Item {
                         }
 
                         StyledToolTip {
-                            visible: profileButton.buttonHovered
+                            show: profileButton.buttonHovered
                             tooltipText: PowerProfile.getProfileDisplayName(profileButton.modelData)
                         }
                     }


### PR DESCRIPTION
Battery Info Section:
- Added large percentage display on right side for better readability
- Separated percentage from status text (now shows 'Charging'/'Full'/'On battery')
- Improved vertical alignment and spacing
- Time remaining info now has proper text elide

Power Profile Buttons:
- Replaced cramped icon+text buttons with icon-only design
- Increased icon size from 14px to 18px for better visibility
- Added tooltips showing full profile name on hover
- Buttons now use full available height

This fixes the issue where power profile names were squished/truncated in the battery popup when space was limited.