### PR TITLE
fix: hide system tray when no items present

### DIFF
--- a/modules/bar/systray/SysTray.qml
+++ b/modules/bar/systray/SysTray.qml
@@ -8,6 +8,9 @@ import qs.modules.components
     variant: "bg"
     id: root
 
+    // Hide when no tray items
+    visible: hasItems
+
     topLeftRadius: root.vertical ? root.startRadius : root.startRadius
     topRightRadius: root.vertical ? root.startRadius : root.endRadius
     bottomLeftRadius: root.vertical ? root.endRadius : root.startRadius
@@ -22,11 +25,14 @@ import qs.modules.components
     // Orientación derivada de la barra
     property bool vertical: bar.orientation === "vertical"
 
+    // Hide completely when empty - check both orientations
+    readonly property bool hasItems: rowRepeater.count > 0 || columnRepeater.count > 0
+
     // Ajustes de tamaño dinámicos según orientación
     height: vertical ? implicitHeight : parent.height
-    Layout.preferredWidth: (vertical ? columnLayout.implicitWidth : rowLayout.implicitWidth) + 16
-    implicitWidth: (vertical ? columnLayout.implicitWidth : rowLayout.implicitWidth) + 16
-    implicitHeight: (vertical ? columnLayout.implicitHeight : rowLayout.implicitHeight) + 16
+    Layout.preferredWidth: hasItems ? ((vertical ? columnLayout.implicitWidth : rowLayout.implicitWidth) + 16) : 0
+    implicitWidth: hasItems ? ((vertical ? columnLayout.implicitWidth : rowLayout.implicitWidth) + 16) : 0
+    implicitHeight: hasItems ? ((vertical ? columnLayout.implicitHeight : rowLayout.implicitHeight) + 16) : 0
 
     RowLayout {
         id: rowLayout
@@ -36,6 +42,7 @@ import qs.modules.components
         spacing: 8
 
         Repeater {
+            id: rowRepeater
             model: SystemTray.items
 
             SysTrayItem {
@@ -54,6 +61,7 @@ import qs.modules.components
         spacing: 8
 
         Repeater {
+            id: columnRepeater
             model: SystemTray.items
 
             SysTrayItem {


### PR DESCRIPTION
Fixes #4

- Added hasItems property using Repeater.count for reliable model counting
- Set visible binding to hasItems
- Set Layout.preferredWidth/implicitWidth/implicitHeight to 0 when empty
- Tray now properly hides when no apps are in the system tray

<img width="76" height="188" alt="Screenshot_2026-02-13-09-08-53" src="https://github.com/user-attachments/assets/9ca80c44-586d-48cb-bd84-9437e1f681a0" />
<img width="66" height="144" alt="Screenshot_2026-02-13-09-09-08" src="https://github.com/user-attachments/assets/c69a34b0-8d09-4b29-9365-ebb4e27e7c9d" />

