### PR TITLE
feat: added button to quickly open config json

### DIFF
--- a/modules/widgets/dashboard/controls/BindsPanel.qml
+++ b/modules/widgets/dashboard/controls/BindsPanel.qml
@@ -579,6 +579,13 @@ Item {
                         onClicked: function () {
                             Config.keybindsLoader.reload();
                         }
+                    },
+                    {
+                        icon: Icons.file,
+                        tooltip: "Open JSON",
+                        onClicked: function () {
+                            Qt.openUrlExternally("file://" + Config.keybindsPath);
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
Added a button to the Binds panel that allows opening the configuration JSON file directly in the system's default editor.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2a6b4e71-8f43-487c-b5bd-9255b8a0d527" />
