### PR TITLE
feat: add calculator utility to launcher

### DIFF
--- a/modules/widgets/launcher/LauncherView.qml
+++ b/modules/widgets/launcher/LauncherView.qml
@@ -173,7 +173,44 @@ Rectangle {
 
         function updateFilteredApps() {
             if (searchText.length > 0) {
-                filteredApps = AppSearch.fuzzyQuery(searchText);
+                var results = AppSearch.fuzzyQuery(searchText);
+                
+                // Utilitário de Conta (Calculadora)
+                let trimmed = searchText.trim();
+                let isMath = /^[0-9.,()+\-*/%\s]+$/.test(trimmed) && /[+\-*/%]/.test(trimmed) && /[0-9]/.test(trimmed);
+                
+                if (isMath) {
+                    try {
+                        let expr = trimmed.replace(/,/g, '.');
+                        let result = Function('"use strict";return (' + expr + ')')();
+                        
+                        if (result !== undefined && result !== null && !isNaN(result) && isFinite(result)) {
+                            let resultStr = result.toString().replace('.', ',');
+                            
+                            let calcApp = {
+                                "id": "calc-result",
+                                "name": "= " + resultStr,
+                                "icon": "accessories-calculator",
+                                "comment": "Resultado da conta (Pressione Enter para copiar)",
+                                "execString": "",
+                                "categories": [],
+                                "runInTerminal": false,
+                                "execute": function() {
+                                    Quickshell.execDetached(["wl-copy", resultStr]);
+                                }
+                            };
+                            
+                            let newResults = [calcApp];
+                            for (var i = 0; i < results.length; i++) {
+                                newResults.push(results[i]);
+                            }
+                            filteredApps = newResults;
+                            return;
+                        }
+                    } catch(e) {}
+                }
+                
+                filteredApps = results;
             } else {
                 filteredApps = AppSearch.getAllApps();
             }
@@ -230,8 +267,10 @@ Rectangle {
             let app = appsById[appId];
             if (app && app.execute) {
                 app.execute();
-                // Record usage for sorting priority
-                UsageTracker.recordUsage(appId);
+                if (appId !== "calc-result") {
+                    // Record usage for sorting priority
+                    UsageTracker.recordUsage(appId);
+                }
             }
         }
 


### PR DESCRIPTION
Added a math utility to the search input that evaluates expressions and allows copying the result.

<img width="915" height="623" alt="image" src="https://github.com/user-attachments/assets/c4e4af83-920c-4c2e-8cb7-909ca26560f8" />
