### PR TITLE
fix(popups): delay focus grab to prevent immediate dismissal

### DIFF
--- a/modules/widgets/overview/OverviewPopup.qml
+++ b/modules/widgets/overview/OverviewPopup.qml
@@ -52,13 +52,19 @@ PanelWindow {
         height: 0
     }
 
+    // Delay focus grab to ensure the PanelWindow surface is mapped before
+    // Hyprland processes the grab request (prevents immediate onCleared race)
+    Timer {
+        id: grabDelay
+        interval: 50
+        onTriggered: focusGrab.active = true
+    }
+
     HyprlandFocusGrab {
         id: focusGrab
         windows: [overviewPopup]
-        active: overviewOpen
 
         onCleared: {
-            // Use Qt.callLater to avoid potential race conditions
             Qt.callLater(() => {
                 if (overviewOpen) {
                     Visibilities.setActiveModule("");
@@ -388,6 +394,7 @@ PanelWindow {
     // Ensure focus when overview opens
     onOverviewOpenChanged: {
         if (overviewOpen) {
+            grabDelay.start();
             Qt.callLater(() => {
                 searchInput.clear();
                 if (overviewLoader.item) {
@@ -395,6 +402,9 @@ PanelWindow {
                 }
                 searchInput.focusInput();
             });
+        } else {
+            grabDelay.stop();
+            focusGrab.active = false;
         }
     }
 }

--- a/modules/widgets/presets/PresetsPopup.qml
+++ b/modules/widgets/presets/PresetsPopup.qml
@@ -52,13 +52,19 @@ PanelWindow {
         height: 0
     }
 
+    // Delay focus grab to ensure the PanelWindow surface is mapped before
+    // Hyprland processes the grab request (prevents immediate onCleared race)
+    Timer {
+        id: grabDelay
+        interval: 50
+        onTriggered: focusGrab.active = true
+    }
+
     HyprlandFocusGrab {
         id: focusGrab
         windows: [presetsPopup]
-        active: presetsOpen
 
         onCleared: {
-            // Use Qt.callLater to avoid potential race conditions
             Qt.callLater(() => {
                 if (presetsOpen) {
                     Visibilities.setActiveModule("");
@@ -222,12 +228,16 @@ PanelWindow {
     // Ensure focus when presets opens
     onPresetsOpenChanged: {
         if (presetsOpen) {
+            grabDelay.start();
             Qt.callLater(() => {
                 if (presetsLoader.item) {
                     presetsLoader.item.resetSearch();
                     presetsLoader.item.focusSearchInput();
                 }
             });
+        } else {
+            grabDelay.stop();
+            focusGrab.active = false;
         }
     }
 }


### PR DESCRIPTION
## Problem

The overview never actually stayed open for me. Every time I hit my keybind it would either close immediately (seeing nothing) or flash briefly before disappearing. The presets popup had the same issue occasionally.

After looking into it, `HyprlandFocusGrab` is bound directly via `active: overviewOpen` (and `active: presetsOpen`), which activates the grab the instant the QML property changes. On Wayland, the `PanelWindow` surface may not yet be mapped by the compositor at that point, so Hyprland processes the grab request, finds no valid surface, and immediately fires `onCleared`, closing the popup before you can interact with it.

Essentially a race condition that depends on compositor timing.

## Solution

Replace the direct `active` property binding with a 50ms `Timer` that starts when the popup opens. This gives the Wayland compositor time to map the surface before the focus grab is activated. On close, the timer is stopped and the grab is explicitly deactivated.

50ms is conservative since surface mapping typically completes within a single frame (~4-16ms), but it provides a safe margin without being perceptible.

## Files Changed

- `modules/widgets/overview/OverviewPopup.qml`: Timer-based grab activation, removed direct binding
- `modules/widgets/presets/PresetsPopup.qml`: Same pattern

## Testing

1. Open/close overview rapidly (~10 times), should never self-dismiss
2. Open/close presets popup rapidly, same expectation
3. Click outside an open popup, should still dismiss correctly via `onCleared`
4. Test on multi-monitor (each screen gets its own PanelWindow)