### PR TITLE
fix(hyprland): use synced rounding value when applying decoration

### DIFF
--- a/modules/services/HyprlandConfig.qml
+++ b/modules/services/HyprlandConfig.qml
@@ -140,7 +140,7 @@ QtObject {
         batchCommand += ` ; keyword general:col.active_border ${activeColorFormatted}`;
         batchCommand += ` ; keyword general:col.inactive_border ${inactiveColorFormatted}`;
         batchCommand += ` ; keyword general:layout ${GlobalStates.hyprlandLayout}`;
-        batchCommand += ` ; keyword decoration:rounding ${Config.hyprland.rounding}`;
+        batchCommand += ` ; keyword decoration:rounding ${Config.hyprlandRounding}`;
         batchCommand += ` ; keyword decoration:shadow:enabled ${Config.hyprland.shadowEnabled}`;
         batchCommand += ` ; keyword decoration:shadow:range ${Config.hyprland.shadowRange}`;
         batchCommand += ` ; keyword decoration:shadow:render_power ${Config.hyprland.shadowRenderPower}`;


### PR DESCRIPTION
## Problem

I noticed the Retro preset's square window borders weren't actually applying. Retro sets `roundness: 0` in its theme config with `syncRoundness: true`, so Hyprland should get 0px rounding for sharp corners. Instead it was still using 16px rounding, giving rounded window borders that don't match the theme at all.

The issue is in `HyprlandConfig.qml` where `syncRoundness` is called to apply the rounding to Hyprland's `decoration:rounding`. It reads `Config.hyprland.rounding` (the raw Hyprland setting, always 16) instead of `Config.hyprlandRounding` (the computed property that checks the `syncRoundness` flag and uses the theme's `roundness` value when sync is enabled).

## Solution

One-line fix: use `Config.hyprlandRounding` instead of `Config.hyprland.rounding` in the `hyprctl` batch command.

`Config.hyprlandRounding` is already defined in Config.qml as:
```qml
property int hyprlandRounding: hyprland.syncRoundness ? roundness : hyprland.rounding
```

So when `syncRoundness` is true (as in Retro), it uses the theme's `roundness` (0), and when false, it falls back to the independent Hyprland setting (16). The property was already there, it just wasn't being used in the right place.

## Files Changed

- `modules/services/HyprlandConfig.qml`: use `Config.hyprlandRounding` instead of `Config.hyprland.rounding`

## Testing

1. Apply Retro preset: window borders should be square (0px rounding)
2. Apply Default or another preset with `syncRoundness: true` and non-zero `roundness`: rounding should match the theme value
3. Set `syncRoundness: false` and change `hyprland.rounding` manually: should use the independent value