### PR TITLE
refactor: improve distro detection reliability in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,11 +25,27 @@ has_font() { fc-list 2>/dev/null | grep -qi "$1"; }
 
 # === Distro Detection ===
 detect_distro() {
-	[[ -f /etc/NIXOS ]] && echo "nixos" && return
-	has_cmd pacman && echo "arch" && return
-	has_cmd dnf && echo "fedora" && return
-	has_cmd apt && echo "debian" && return
-	echo "unknown"
+    if [[ -f /etc/os-release ]]; then
+        local id
+        id=$(. /etc/os-release && echo "${ID,,}")
+        case "$id" in
+            nixos)               echo "nixos"   ;;
+            arch | manjaro | endeavouros) echo "arch" ;;
+            fedora | rhel | centos | rocky | almalinux | alma) echo "fedora" ;;
+            debian | ubuntu | mint | pop)  echo "debian" ;;
+            *)                   echo "$id"     ;;
+        esac
+        return 0
+    else
+        #
+        # Fallbacks to original Ambxst detection method
+        #
+        [[ -f /etc/NIXOS ]] && echo "nixos" && return
+        has_cmd pacman && echo "arch" && return
+        has_cmd dnf && echo "fedora" && return
+        has_cmd apt && echo "debian" && return
+        echo "unknown"
+    fi
 }
 
 DISTRO=$(detect_distro)


### PR DESCRIPTION
## Problem

The original distro detection relied solely on checking for the presence of package manager binaries (`pacman`, `dnf`, `apt`) and a single NixOS-specific file. This approach had two issues:

- **Derivative distros** (e.g. AlmaLinux, Rocky, Manjaro, EndeavourOS) were not explicitly handled, so detection could fail or return an unexpected value depending on the environment.
- **Package manager checks** are inherently fragile — some distros ship with multiple package managers (and users can install additional ones) or have binaries available that don't represent the primary one.

<img width="630" height="347" alt="image" src="https://github.com/user-attachments/assets/eb35f02a-4a61-44c2-8d6e-e6c603e47b02" />

## Solution

[c45eec9](https://github.com/Axenide/Ambxst/commit/c45eec93af153ab642f349a75963d8eb92bc55df): Rewrote `detect_distro()` to use `/etc/os-release` as the primary detection method, which is the modern Linux standard and available on all major distributions. The `ID` field is matched case-insensitively against known distro families:

| Detected as | Covers |
|-------------|--------|
| `arch`      | arch, manjaro, endeavouros |
| `fedora`    | fedora, rhel, centos, rocky, almalinux, alma |
| `debian`    | debian, ubuntu, mint, pop |
| `nixos`     | nixos |

The original package manager / file-based checks are kept as a **fallback** for edge cases where `/etc/os-release` is absent.

## Testing

Tested via Docker across 5 distributions:

| Distro | Expected | Result |
|--------|----------|--------|
| `ubuntu:latest` | `debian` |  `debian` |
| `debian:latest` | `debian` |  `debian` |
| `fedora:latest` | `fedora` |  `fedora` |
| `almalinux:latest` | `fedora` |  `fedora` |
| `archlinux:latest` | `arch` |  `arch` |

### Test Scripts

- `test.sh`
```bash
for distro in ubuntu:latest debian:latest fedora:latest almalinux:latest archlinux:latest; do
    echo "=== $distro ==="
    docker run --rm -v "$PROJECT/detect_distro.sh:/test.sh" "$distro" bash /test.sh
done
```

- `detect_distro.sh` (which is a cut down snippet from original `install.sh`)
```bash
GREEN='\033[0;32m' BLUE='\033[0;34m' YELLOW='\033[1;33m' RED='\033[0;31m' NC='\033[0m'
log_info() { echo -e "${BLUE}ℹ  $1${NC}" >&2; }
has_cmd() { command -v "$1" >/dev/null 2>&1; }

detect_distro() {
    if [[ -f /etc/os-release ]]; then
        local id
        id=$(. /etc/os-release && echo "${ID,,}")
        case "$id" in
            nixos)               echo "nixos"   ;;
            arch | manjaro | endeavouros) echo "arch" ;;
            fedora | rhel | centos | rocky | almalinux | alma) echo "fedora" ;;
            debian | ubuntu | mint | pop)  echo "debian" ;;
            *)                   echo "$id"     ;;
        esac
        return 0
    else
        #
        # Fallbacks to original Ambxst detection method
        #
        [[ -f /etc/NIXOS ]] && echo "nixos" && return
        has_cmd pacman && echo "arch" && return
        has_cmd dnf && echo "fedora" && return
        has_cmd apt && echo "debian" && return
        echo "unknown"
    fi
}

DISTRO=$(detect_distro)
log_info "Detected: $DISTRO"
```

### Results

<img width="257" height="250" alt="image" src="https://github.com/user-attachments/assets/e67b840c-1d86-4e00-b475-b23c6f97e9da" />
