### PR TITLE
fix(locale): changes "C" locale to "C.UTF-8"

### DIFF
--- a/modules/services/BluetoothService.qml
+++ b/modules/services/BluetoothService.qml
@@ -306,8 +306,8 @@ Singleton {
         running: false
         property string buffer: ""
         environment: ({
-            LANG: "C",
-            LC_ALL: "C"
+            LANG: "C.UTF-8",
+            LC_ALL: "C.UTF-8"
         })
         stdout: SplitParser {
             onRead: data => {

--- a/modules/services/EasyEffectsService.qml
+++ b/modules/services/EasyEffectsService.qml
@@ -90,7 +90,7 @@ Singleton {
         id: bypassStateProcess
         command: ["easyeffects", "-b", "3"]
         running: false
-        environment: ({ LANG: "C", LC_ALL: "C" })
+        environment: ({ LANG: "C.UTF-8", LC_ALL: "C.UTF-8" })
         stdout: SplitParser {
             onRead: data => {
                 const val = data.trim();
@@ -135,7 +135,7 @@ Singleton {
         command: ["easyeffects", "-p"]
         running: false
         property string buffer: ""
-        environment: ({ LANG: "C", LC_ALL: "C" })
+        environment: ({ LANG: "C.UTF-8", LC_ALL: "C.UTF-8" })
         stdout: SplitParser {
             onRead: data => {
                 presetsProcess.buffer += data + "\n";
@@ -186,7 +186,7 @@ Singleton {
         command: ["easyeffects", "-a"]
         running: false
         property string buffer: ""
-        environment: ({ LANG: "C", LC_ALL: "C" })
+        environment: ({ LANG: "C.UTF-8", LC_ALL: "C.UTF-8" })
         stdout: SplitParser {
             onRead: data => {
                 activePresetsProcess.buffer += data + "\n";

--- a/modules/services/NetworkService.qml
+++ b/modules/services/NetworkService.qml
@@ -300,8 +300,8 @@ Singleton {
         command: ["nmcli", "radio", "wifi"]
         running: true
         environment: ({
-            LANG: "C",
-            LC_ALL: "C"
+            LANG: "C.UTF-8",
+            LC_ALL: "C.UTF-8"
         })
         stdout: SplitParser {
             onRead: data => {
@@ -315,8 +315,8 @@ Singleton {
         running: false
         command: ["nmcli", "-g", "ACTIVE,SIGNAL,FREQ,SSID,BSSID,SECURITY", "d", "w"]
         environment: ({
-            LANG: "C",
-            LC_ALL: "C"
+            LANG: "C.UTF-8",
+            LC_ALL: "C.UTF-8"
         })
         property string buffer: ""
         stdout: SplitParser {


### PR DESCRIPTION
plain C locale generates warnings in easyeffects processes:

```
Mar 04 21:23:43 archlinux easyeffects[1378519]: Detected locale "C" with character encoding "ANSI_X3.4-1968", which is not UTF-8.
                                                Qt depends on a UTF-8 locale, and has switched to "C.UTF-8" instead.
                                                If this causes problems, reconfigure your locale. See the locale(1) manual
                                                for more information.
```

this commit gets rid of those warnings, and potentially others in different services.