### PR TITLE
Remove focus on hover current workspace in overview

### DIFF
--- a/modules/widgets/overview/OverviewWindow.qml
+++ b/modules/widgets/overview/OverviewWindow.qml
@@ -250,17 +250,6 @@ Item {
 
         onEntered: {
             root.hovered = true;
-            // Only focus window on hover if it's in the current workspace
-            if (root.windowData) {
-                // Get current active workspace from Hyprland
-                let currentWorkspace = Hyprland.focusedMonitor?.activeWorkspace?.id;
-                let windowWorkspace = root.windowData?.workspace?.id;
-
-                // Only focus if the window is in the current workspace
-                if (currentWorkspace && windowWorkspace && currentWorkspace === windowWorkspace) {
-                    Hyprland.dispatch(`focuswindow address:${windowData.address}`);
-                }
-            }
         }
         onExited: root.hovered = false
 


### PR DESCRIPTION
Removed focus when hovering windows that are in current workspace. This should remove the sudden jump of the mouse that happened there as referenced in https://github.com/Axenide/Ambxst/issues/99