### PR TITLE
matugen update fix

### DIFF
--- a/modules/widgets/dashboard/wallpapers/Wallpaper.qml
+++ b/modules/widgets/dashboard/wallpapers/Wallpaper.qml
@@ -377,7 +377,7 @@ PanelWindow {
             }
 
             // Ejecutar matugen con configuración específica
-            var commandWithConfig = ["matugen", "image", matugenSource, "-c", decodeURIComponent(Qt.resolvedUrl("../../../../assets/matugen/config.toml").toString().replace("file://", "")), "-t", wallpaperConfig.adapter.matugenScheme];
+            var commandWithConfig = ["matugen", "image", matugenSource, "--source-color-index", "0", "-c", decodeURIComponent(Qt.resolvedUrl("../../../../assets/matugen/config.toml").toString().replace("file://", "")), "-t", wallpaperConfig.adapter.matugenScheme];
             if (Config.theme.lightMode) {
                 commandWithConfig.push("-m", "light");
             }
@@ -385,7 +385,7 @@ PanelWindow {
             matugenProcessWithConfig.running = true;
 
             // Ejecutar matugen normal en paralelo
-            var commandNormal = ["matugen", "image", matugenSource, "-t", wallpaperConfig.adapter.matugenScheme];
+            var commandNormal = ["matugen", "image", matugenSource, "--source-color-index", "0", "-t", wallpaperConfig.adapter.matugenScheme];
             if (Config.theme.lightMode) {
                 commandNormal.push("-m", "light");
             }


### PR DESCRIPTION
In the newest matugen 4.0 update. They added the option to select source color from a list of options, but since matugen is not run through the terminal it breaks. This patch auto selects the first option, just like they did before the update.

<img width="510" height="121" alt="image" src="https://github.com/user-attachments/assets/f7015dc0-6e1a-46b2-85f6-5fa2d4a0673a" />

<img width="863" height="442" alt="image" src="https://github.com/user-attachments/assets/dd6bdf53-ccef-4b9e-830f-59b06075a591" />
