### PR TITLE
Chore: Updated command for nix profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,7 @@ install_dependencies() {
 			nix profile upgrade Ambxst --refresh --impure
 		else
 			log_info "Installing Ambxst..."
-			nix profile add "$FLAKE_URI" --impure
+			nix profile install "$FLAKE_URI" --impure
 		fi
 		;;
 


### PR DESCRIPTION
On current nix version:

 > nix profile add
error: 'add' is not a recognised command
Try 'nix --help' for more information.

