### PR TITLE
fix(color picker): remove background color overlay from color picker

### DIFF
--- a/scripts/colorpicker.py
+++ b/scripts/colorpicker.py
@@ -24,7 +24,7 @@ for dep in ("grim", "slurp", "magick", "wl-copy", "notify-send"):
         )
         sys.exit(1)
 
-coords = cmd("slurp", "-p").decode().strip()
+coords = cmd("slurp", "-p", "-b", "00000000").decode().strip()
 if not coords:
     sys.exit(0)
 


### PR DESCRIPTION
The overlay currently affects the actual colour that the colour picker finds, which is not how that should work.