### PR TITLE
Low-Battery Notification alert with sound

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -1005,6 +1005,11 @@ Singleton {
         adapter: JsonAdapter {
             property list<string> disks: ["/"]
             property bool updateServiceEnabled: true
+            property JsonObject batteryNotifications: JsonObject {
+                property bool enabled: true
+                property int lowThreshold: 20
+                property int criticalThreshold: 10
+            }
             property JsonObject idle: JsonObject {
                 property JsonObject general: JsonObject {
                     property string lock_cmd: "ambxst lock"

--- a/modules/services/BatteryAlertService.qml
+++ b/modules/services/BatteryAlertService.qml
@@ -1,0 +1,159 @@
+pragma Singleton
+
+import QtQuick
+import QtMultimedia
+import Quickshell
+import Quickshell.Io
+import qs.config
+
+Singleton {
+    id: root
+
+    readonly property var settings: Config.system && Config.system.batteryNotifications ? Config.system.batteryNotifications : null
+    readonly property bool enabled: settings && settings.enabled !== undefined ? settings.enabled : true
+    readonly property int lowThreshold: settings && settings.lowThreshold !== undefined ? settings.lowThreshold : 20
+    readonly property int criticalThreshold: settings && settings.criticalThreshold !== undefined ? settings.criticalThreshold : 10
+
+    property bool lowNotified: false
+    property bool criticalNotified: false
+
+    function resetNotificationState() {
+        lowNotified = false;
+        criticalNotified = false;
+    }
+
+    function sendNotification(summary, body, urgency) {
+        notificationProcess.running = false;
+        notificationProcess.command = [
+            "notify-send",
+            "-a", "Ambxst Battery",
+            "-u", urgency,
+            "-i", "battery-caution",
+            summary,
+            body
+        ];
+        notificationProcess.running = true;
+        warningSound.play();
+    }
+
+    function checkBatteryState() {
+        if (!enabled || !Battery.available || SuspendManager.isSuspending) {
+            return;
+        }
+
+        if (Battery.isPluggedIn || Battery.isCharging) {
+            resetNotificationState();
+            return;
+        }
+
+        const low = Math.max(lowThreshold, criticalThreshold);
+        const critical = Math.min(lowThreshold, criticalThreshold);
+        const percentage = Math.round(Battery.percentage);
+        const timeRemaining = Battery.timeToEmpty !== "" ? ` About ${Battery.timeToEmpty} remaining.` : "";
+
+        if (percentage > low) {
+            resetNotificationState();
+            return;
+        }
+
+        if (percentage <= critical) {
+            if (!criticalNotified) {
+                sendNotification(
+                    `Battery critical (${percentage}%)`,
+                    `Plug in your charger now.${timeRemaining}`,
+                    "critical"
+                );
+                criticalNotified = true;
+            }
+            lowNotified = true;
+            return;
+        }
+
+        if (!lowNotified) {
+            sendNotification(
+                `Battery low (${percentage}%)`,
+                `Battery is getting low.${timeRemaining}`,
+                "normal"
+            );
+            lowNotified = true;
+        }
+    }
+
+    Process {
+        id: notificationProcess
+        running: false
+        command: []
+    }
+
+    SoundEffect {
+        id: warningSound
+        source: Quickshell.shellDir + "/assets/sound/polite-warning-tone.wav"
+        volume: 1.0
+    }
+
+    Connections {
+        target: Battery
+        function onPercentageChanged() {
+            root.checkBatteryState();
+        }
+        function onIsPluggedInChanged() {
+            root.checkBatteryState();
+        }
+        function onIsChargingChanged() {
+            root.checkBatteryState();
+        }
+        function onAvailableChanged() {
+            root.checkBatteryState();
+        }
+    }
+
+    Connections {
+        target: root.settings
+        ignoreUnknownSignals: true
+        function onEnabledChanged() {
+            if (!root.enabled) {
+                root.resetNotificationState();
+            } else {
+                root.checkBatteryState();
+            }
+        }
+        function onLowThresholdChanged() {
+            root.resetNotificationState();
+            root.checkBatteryState();
+        }
+        function onCriticalThresholdChanged() {
+            root.resetNotificationState();
+            root.checkBatteryState();
+        }
+    }
+
+    Connections {
+        target: SuspendManager
+        function onWakingUp() {
+            wakeCheckTimer.restart();
+        }
+    }
+
+    Timer {
+        id: startupCheckTimer
+        interval: 5000
+        running: true
+        repeat: false
+        onTriggered: root.checkBatteryState()
+    }
+
+    Timer {
+        id: wakeCheckTimer
+        interval: 3000
+        repeat: false
+        onTriggered: root.checkBatteryState()
+    }
+
+    Timer {
+        id: pollTimer
+        interval: 60000
+        running: true
+        repeat: true
+        onTriggered: root.checkBatteryState()
+    }
+}

--- a/modules/services/BatteryAlertService.qml
+++ b/modules/services/BatteryAlertService.qml
@@ -26,7 +26,7 @@ Singleton {
         notificationProcess.running = false;
         notificationProcess.command = [
             "notify-send",
-            "-a", "Ambxst Battery",
+
             "-u", urgency,
             "-i", "battery-caution",
             summary,

--- a/shell.qml
+++ b/shell.qml
@@ -287,6 +287,7 @@ ShellRoot {
                 let _ = CaffeineService.inhibit;
                 _ = IdleService.lockCmd; // Force init
                 _ = GlobalShortcuts.appId; // Force init (IPC pipe listener)
+                _ = BatteryAlertService.enabled; 
             });
         }
     }


### PR DESCRIPTION
Added low-battery notifications with **_warning sound_**

It watches your battery level and sends a notification with **warning sound** when it gets low or critical, based on defined threshold values

# **Critical threshold (Set to 10%)**
<img width="566" height="149" alt="image" src="https://github.com/user-attachments/assets/6c3c3bd7-53c0-4763-8cf5-9721641bb61e" />
<img width="385" height="383" alt="image" src="https://github.com/user-attachments/assets/1bd1ca01-e6f3-4978-a595-e30d07caf5b1" />

https://github.com/user-attachments/assets/3c480e63-d29f-4514-b21e-bf4ba8c545a6



# **Low Threshold (Set to 20%)**
<img width="500" height="111" alt="image" src="https://github.com/user-attachments/assets/4e8bdf53-38d3-4bfd-9231-9747c2c79571" />
<img width="360" height="366" alt="image" src="https://github.com/user-attachments/assets/fb1581dc-1156-42ae-94c0-afafa8409e24" />

https://github.com/user-attachments/assets/8220dcb0-d6cd-447c-b78b-f7ee1472582d






Changed the threshold values for screenshot purpose 🥀

