### PR TITLE
change gemini default ai model as 2.0 flash is no longer available

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -1178,7 +1178,7 @@ Singleton {
             property string systemPrompt: "You are a helpful assistant running on a Linux system. You have access to some tools to control the system."
             property string tool: "none"
             property list<var> extraModels: []
-            property string defaultModel: "gemini-2.0-flash"
+            property string defaultModel: "gemini-2.5-flash-lite"
             property int sidebarWidth: 400
             property string sidebarPosition: "right"
             property bool sidebarPinnedOnStartup: false

--- a/config/defaults/ai.js
+++ b/config/defaults/ai.js
@@ -2,7 +2,7 @@ var data = {
     "systemPrompt": "You are a helpful assistant running on a Linux system. You have access to some tools to control the system.",
     "tool": "none",
     "extraModels": [],
-    "defaultModel": "gemini-2.0-flash",
+    "defaultModel": "gemini-2.5-flash-lite",
     "sidebarWidth": 400,
     "sidebarPosition": "right",
     "sidebarPinnedOnStartup": false

--- a/modules/services/Ai.qml
+++ b/modules/services/Ai.qml
@@ -32,7 +32,7 @@ Singleton {
     }
 
     function restoreModel() {
-        const lastModelId = StateService.get("lastAiModel", "gemini-2.0-flash");
+        const lastModelId = StateService.get("lastAiModel", "gemini-2.5-flash-lite");
         savedModelId = lastModelId;
         tryRestore();
         persistenceReady = true;


### PR DESCRIPTION
Change the default shell Gemini model to **gemini-2.5-flash-lite**, since **2.5 Flash has been discontinued by Google**.
