### PR TITLE
fix(launcher): drawer launches Terminal=true apps via xdg-terminal-exec

### DIFF
--- a/modules/services/AppSearch.qml
+++ b/modules/services/AppSearch.qml
@@ -209,9 +209,14 @@ Singleton {
 
             if (safeArgs.length > 0) {
                 const cmdString = safeArgs.join(" ");
+                // Wrap Terminal=true entries via xdg-terminal-exec (freedesktop default-terminal-spec).
+                // Users must have xdg-terminal-exec installed and ~/.config/xdg-terminals.list configured.
+                const wrapped = app.runInTerminal
+                    ? "xdg-terminal-exec " + cmdString
+                    : cmdString;
                 const p = Qt.createQmlObject('import Quickshell.Io; Process { }', root);
                 // Run in background, detached, from HOME
-                p.command = ["bash", "-c", "cd ~ && setsid " + cmdString + " > /dev/null 2>&1 &"];
+                p.command = ["bash", "-c", "cd ~ && setsid " + wrapped + " > /dev/null 2>&1 &"];
                 p.running = true;
                 return;
             }

--- a/modules/widgets/launcher/LauncherView.qml
+++ b/modules/widgets/launcher/LauncherView.qml
@@ -227,9 +227,12 @@ Rectangle {
 
         function executeApp(appId) {
             let app = appsById[appId];
-            if (app && app.execute) {
-                app.execute();
-                // Record usage for sorting priority
+            if (app) {
+                // Delegate to AppSearch.launchApp for consistency with DockAppButton.
+                // app.execute() (Quickshell DesktopEntry) does not handle Terminal=true
+                // entries: TUI apps (btop, htop, nvim, ranger, etc.) launched from the
+                // drawer fail silently because the Exec is run without a terminal wrapper.
+                AppSearch.launchApp(app);
                 UsageTracker.recordUsage(appId);
             }
         }


### PR DESCRIPTION
## Problem

The app drawer (`SUPER` keybind) silently fails to launch any `.desktop` entry that has `Terminal=true` — e.g. **btop**, **htop**, **nvim**, **ranger**, **lazygit**, etc. Clicking these does literally nothing: no error, no flash, no terminal window. The behavior is hard to debug because the failure is invisible.

## Root cause

`LauncherView.executeApp()` (line 228) calls Quickshell's `DesktopEntry.execute()` directly:

```qml
if (app && app.execute) {
    app.execute();
}
```

Quickshell's `DesktopEntry.execute()` (at least in older / illogical-impulse-quickshell-git 0.2.0) does not wrap `Terminal=true` entries in a terminal emulator — it simply runs the `Exec` line, which causes the TUI binary to crash immediately when stdin/stdout aren't a TTY.

Meanwhile, **`DockAppButton.qml:184`** already uses `AppSearch.launchApp()` for the same purpose, which handles process spawning correctly via `bash -c "setsid ..."`. So the drawer was inconsistent with the dock.

## Fix

Two minimal changes:

1. **`LauncherView.qml`** — `executeApp()` now delegates to `AppSearch.launchApp(app)`, matching the dock's behavior. Unifies app-launch logic across the shell.

2. **`AppSearch.qml`** — `launchApp()` now prepends `xdg-terminal-exec` to the command when the entry's `runInTerminal` is true. `xdg-terminal-exec` is the freedesktop [default-terminal-spec](https://wiki.freedesktop.org/wiki/Specifications/default-terminal-spec/) wrapper — the canonical way to launch TUI apps from a desktop launcher.

## Requirements for users

After this fix, users need to have `xdg-terminal-exec` installed (AUR on Arch, packaged on most modern distros) and configured via `~/.config/xdg-terminals.list`:

```
kitty.desktop
```

(or `alacritty.desktop`, `foot.desktop`, etc.)

Worth mentioning in the README under "Requirements" — happy to add that in a follow-up if requested.

## Testing

Reproduced the bug with:
- `btop` (Console-only, Terminal=true)
- `htop` (same)
- `nvim` (Terminal=true)
- `ranger` (Terminal=true)

Before this patch: silent failure for all four.  
After this patch: each one opens correctly in `kitty` (the configured terminal via `xdg-terminals.list`).

GUI apps (Brave, Dolphin, etc.) continue to work unchanged — `runInTerminal` is false, the wrap branch is skipped, behavior is identical to before.

## Diff stats

```
modules/services/AppSearch.qml            | 7 ++++++-
modules/widgets/launcher/LauncherView.qml | 9 ++++++---
2 files changed, 12 insertions(+), 4 deletions(-)
```

---

This is the first of a series of fixes I want to upstream from a longer debugging session on a CachyOS + Ambxst setup. Each subsequent fix will be its own PR to keep review focused. Happy to iterate based on feedback.