### PR TITLE
feat(ai): wire Config.ai.extraModels for user-defined OpenAI-compat providers

### DIFF
--- a/modules/services/Ai.qml
+++ b/modules/services/Ai.qml
@@ -778,6 +778,17 @@ for f in files:
             fetchProcessMiniMax.running = true;
         }
 
+        // extraModels — user-defined OpenAI-compatible providers (Moonshot/Kimi,
+        // OpenRouter, LMStudio remote, local llama.cpp, etc.). Each entry in
+        // Config.ai.extraModels declares an AiModel with endpoint + model + provider.
+        // Entries that require_key look up the key from KeyStore by key_provider
+        // (default "custom"). See readme for the entry schema.
+        if (Config.ai.extraModels && Config.ai.extraModels.length > 0) {
+            pendingFetches++;
+            fetchProcessExtraModels.command = ["bash", "-c", "echo 'done'"];
+            fetchProcessExtraModels.running = true;
+        }
+
         if (pendingFetches === 0) {
             fetchingModels = false;
         }
@@ -1042,6 +1053,55 @@ for f in files:
                 }
                 
                 mergeModels(newModels);
+            }
+            checkFetchCompletion();
+        }
+    }
+
+    // User-defined OpenAI-compatible models from Config.ai.extraModels.
+    // Entry schema (each item in the array):
+    //   {
+    //     "name":         "Display name",                    // shown in selector
+    //     "model":        "model-id-for-api",                // sent in request body
+    //     "endpoint":     "https://api.example.com/v1",      // OpenAI-compat base URL
+    //     "provider":     "custom",                          // strategy key (default: "custom")
+    //     "icon":         "openai",                          // optional icon name
+    //     "description":  "Free text",                       // optional
+    //     "requires_key": true,                              // optional, default true
+    //     "key_provider": "custom"                           // optional, KeyStore lookup key (default: "custom")
+    //   }
+    Process {
+        id: fetchProcessExtraModels
+        onExited: exitCode => {
+            if (exitCode === 0) {
+                let newModels = [];
+                let extras = Config.ai.extraModels || [];
+                for (let i = 0; i < extras.length; i++) {
+                    let entry = extras[i];
+                    if (!entry || !entry.model || !entry.endpoint) continue;
+
+                    let provider = entry.provider || "custom";
+                    let requiresKey = entry.requires_key !== false; // default true
+                    let keyProvider = entry.key_provider || "custom";
+
+                    // Skip entries that need a key but none is configured
+                    if (requiresKey && !KeyStore.getKey(keyProvider)) continue;
+
+                    let iconName = entry.icon || provider;
+                    let iconUrl = Qt.resolvedUrl("../../assets/aiproviders/" + iconName + ".svg");
+
+                    let m = aiModelFactory.createObject(root, {
+                        name: entry.name || entry.model,
+                        icon: iconUrl,
+                        description: entry.description || ("Custom: " + entry.model),
+                        endpoint: entry.endpoint,
+                        model: entry.model,
+                        provider: provider,
+                        requires_key: requiresKey
+                    });
+                    if (m) newModels.push(m);
+                }
+                if (newModels.length > 0) mergeModels(newModels);
             }
             checkFetchCompletion();
         }


### PR DESCRIPTION
## Context

`Config.ai.extraModels` is declared in the schema:

- `config/defaults/ai.js:4` → `"extraModels": []`
- `config/Config.qml:1180` → `property list<var> extraModels: []`

But it's **never consumed** anywhere in the codebase (verified with `grep -rn extraModels`). As a result, users have no way to register custom OpenAI-compatible providers — Moonshot/Kimi, OpenRouter, LMStudio remote, llama.cpp HTTP servers, free-tier providers, etc. — beyond the hardcoded list (Gemini/OpenAI/Mistral/Groq/Anthropic/Ollama/MiniMax).

The `AiPanel.qml` UI has a **"Custom Provider"** section with fields for API Key + Endpoint + cURL Template, but only the API Key Save button is wired — the Endpoint and cURL Template fields try to persist to `Config.ai.customEndpoint` and `Config.ai.customCurlTemplate`, neither of which exist in the schema. So the full "Custom Provider" flow is broken upstream.

## What this PR does

Wires `Config.ai.extraModels` end-to-end so users can configure arbitrary OpenAI-compat providers without UI changes (UI changes can be a follow-up). `fetchAvailableModels()` now iterates the array and registers each entry as a regular `AiModel`.

The `"custom"` provider already routes to `OpenAiApiStrategy` via `getStrategyForProvider()` (Ai.qml:117), so the request/parse path is already correct.

## Entry schema (`~/.config/ambxst/config/ai.json`)

```json
{
    "extraModels": [
        {
            "name":         "Kimi K2 (0905)",
            "model":        "kimi-k2-0905-preview",
            "endpoint":     "https://api.moonshot.ai/v1",
            "provider":     "custom",
            "description":  "Moonshot K2 preview",
            "requires_key": true,
            "key_provider": "custom"
        },
        {
            "name":         "Local Llama 3",
            "model":        "llama-3-70b",
            "endpoint":     "http://localhost:8080/v1",
            "provider":     "custom",
            "requires_key": false
        }
    ]
}
```

- `provider: "custom"` → uses `OpenAiApiStrategy` (default for unknown providers anyway).
- `requires_key: true` (default) → looks up API key from KeyStore under `key_provider` (default `"custom"`). The existing **"Custom Provider API Key"** Save button in `AiPanel.qml` populates that KeyStore entry — so the end-to-end flow works without UI changes.
- `requires_key: false` → for local/no-auth endpoints (Ollama remote, llama.cpp without keys, etc.).

## Why this approach

- **Uses an existing schema field** — no Config.qml changes, no schema migration.
- **No UI changes required** — the existing API Key Save button is enough; users edit `ai.json` for the rest, same pattern as `systemPrompt`.
- **Future UI can be a follow-up PR** — `AiPanel.qml`'s broken "Custom Provider" Endpoint/cURL fields could be reworked to manage `extraModels` entries directly, but that's a UX call best made separately.
- **Generic** — works for *any* OpenAI-compat provider, not just Moonshot. Adding the next provider doesn't require new code.

## Tested with

- **Moonshot / Kimi**: registered `kimi-k2-0905-preview`, `kimi-k2.6`, `kimi-k2-thinking`, `moonshot-v1-{8k,32k,128k}` — all appear in dropdown, requests fire correctly, responses parse via `OpenAiApiStrategy`.
- **Verified key flow**: storing `sk-...` via the existing "Custom Provider API Key" Save button + adding entries to `ai.json` produced working models with zero panel-level glitches.

## Diff stats

```
modules/services/Ai.qml | 58 ++++++++++++++++++++++++++++++++++++++++
1 file changed, 58 insertions(+)
```

## Related PRs

This is the third in a series of Ambxst fixes. Related:

- #174 — fix(launcher): drawer launches Terminal=true apps
- #175 — fix(icons): resolve icon via StartupWMClass

A follow-up PR will add `reasoning_content` + dynamic-temperature support so thinking models (Kimi K2.5/K2.6, GPT-o1, Claude thinking variants) work via the same flow.