### PR TITLE
feat(ai): support thinking/reasoning models in OpenAI-compatible strategy

### DIFF
--- a/modules/services/ai/strategies/OpenAiApiStrategy.qml
+++ b/modules/services/ai/strategies/OpenAiApiStrategy.qml
@@ -41,10 +41,17 @@ ApiStrategy {
         return formatted;
     }
     function getBody(messages, model, tools) {
+        // Thinking / reasoning models reject temperature != 1 (Kimi K2.5/K2.6,
+        // kimi-*-thinking, GPT o1 family, etc.). Send temperature=1 for those;
+        // keep 0.7 for everything else.
+        let temp = 0.7;
+        if (model.model && /k2\.(5|6)|thinking|^o1(-|$)/.test(model.model)) {
+            temp = 1;
+        }
         let body = {
             model: model.model,
             messages: _formatMessages(messages),
-            temperature: 0.7
+            temperature: temp
         };
         if (tools && tools.length > 0) {
             body.tools = tools.map(t => ({
@@ -80,7 +87,12 @@ ApiStrategy {
                         }
                     };
                 }
-                return { content: msg.content };
+                // Thinking models include reasoning_content alongside (or instead of) content
+                let outContent = msg.content || "";
+                if (msg.reasoning_content && !outContent) {
+                    outContent = msg.reasoning_content;
+                }
+                return { content: outContent };
             }
             if (json.error)
                 return { content: "API Error: " + json.error.message };
@@ -107,6 +119,12 @@ ApiStrategy {
                 let delta = json.choices[0].delta;
                 if (delta && delta.content)
                     return { content: delta.content, done: false, error: null };
+
+                // Thinking models (Kimi K2.5/K2.6, kimi-*-thinking, GPT o1, etc.)
+                // emit reasoning_content BEFORE the final content. Surface it so the
+                // response buffer fills and the user sees the model's chain-of-thought.
+                if (delta && delta.reasoning_content)
+                    return { content: delta.reasoning_content, done: false, error: null };
 
                 // Check for tool calls in stream
                 if (delta && delta.tool_calls) {


### PR DESCRIPTION
## Problem

OpenAI-compatible *thinking* / *reasoning* models — Kimi K2.5, K2.6, kimi-`*`-thinking variants, GPT o1 family — fail silently in the AI panel with the generic message **"No response received from the API."**, regardless of prompt.

There are two distinct upstream causes, both in `OpenAiApiStrategy.qml`:

### Cause 1: hardcoded `temperature: 0.7`

`getBody()` hardcodes `temperature: 0.7`. Thinking models **reject any temperature other than `1`** with HTTP 400:

```json
{
    "error": {
        "message": "invalid temperature: only 1 is allowed for this model",
        "type": "invalid_request_error"
    }
}
```

The error is a single-line JSON, so the SSE-parsing `SplitParser` ignores it (no `data:` prefix), and `curl` exits 0 with the buffer never populated → the panel falls into its "no streaming data received" branch and shows the generic placeholder.

### Cause 2: parser ignores `reasoning_content`

Thinking models stream their chain-of-thought as `delta.reasoning_content` *before* emitting the actual answer as `delta.content`. The existing parser only checks `delta.content`:

```qml
if (delta && delta.content)
    return { content: delta.content, done: false, error: null };
```

All reasoning chunks are dropped. By the time the actual `delta.content` chunks arrive (sometimes hundreds of reasoning chunks later), various downstream timing issues kick in — buffer's still empty, parser misses the small content tail, etc. Either way: user sees nothing.

Reproduced empirically against `api.moonshot.ai/v1`: a "hola" prompt to `kimi-k2.6` produced **196 `reasoning_content` chunks** then **2 `content` chunks** ("Hola"). The 196-to-2 ratio is typical.

## What this PR does

Two minimal additive changes in `OpenAiApiStrategy.qml`:

### 1. Dynamic temperature

```diff
+let temp = 0.7;
+if (model.model && /k2\.(5|6)|thinking|^o1(-|$)/.test(model.model)) {
+    temp = 1;
+}
 let body = {
     model: model.model,
     messages: _formatMessages(messages),
-    temperature: 0.7
+    temperature: temp
 };
```

Regex covers:
- `k2.5`, `k2.6` (Kimi K2.5/K2.6 vision-and-thinking)
- `*thinking*` (kimi-thinking-preview, kimi-k2-thinking, kimi-k2-thinking-turbo, …)
- `o1`, `o1-preview`, `o1-mini`, etc. (OpenAI reasoning family)

### 2. `reasoning_content` accumulation

`parseStreamChunk()`:
```diff
 if (delta && delta.content)
     return { content: delta.content, done: false, error: null };

+if (delta && delta.reasoning_content)
+    return { content: delta.reasoning_content, done: false, error: null };
```

`parseResponse()` (non-stream):
```diff
+let outContent = msg.content || "";
+if (msg.reasoning_content && !outContent) {
+    outContent = msg.reasoning_content;
+}
-return { content: msg.content };
+return { content: outContent };
```

Surfaces the model's chain-of-thought as it streams in, then the final answer concatenated at the end — same flow as ChatGPT-o1 and Claude thinking UIs. Non-thinking models are unchanged.

## Tested with

- **Kimi K2.6** (heavy thinking, 196+ reasoning chunks per short prompt) — works.
- **Kimi K2 (0905 preview)** (no thinking, direct content stream) — unchanged, works.
- **Moonshot v1 family** (no thinking) — unchanged, works.

## Visual note

Reasoning and final answer arrive in the **same chat bubble**, concatenated. Could be polished in a follow-up that renders them in separate styled sections (greyed-out reasoning block + answer below), but that's a UX call worth its own PR.

## Diff stats

```
modules/services/ai/strategies/OpenAiApiStrategy.qml | 20 +++++++++++++++++---
1 file changed, 17 insertions(+), 3 deletions(-)
```

## Related

- Depends on #176 to register custom OpenAI-compatible providers (Kimi/Moonshot) via `Config.ai.extraModels` — otherwise users can't even select a thinking model to test against. Without #176, the temperature fix still helps any built-in provider that ever adds thinking variants.