### PR TITLE
brightness: match monitors by DRM connector, per-monitor setProc

### DIFF
--- a/modules/services/Brightness.qml
+++ b/modules/services/Brightness.qml
@@ -113,6 +113,9 @@ Singleton {
                 const modelLine = lines.find(l => l.startsWith("Model:"));
                 const monitorLine = lines.find(l => l.startsWith("Monitor:"));
                 const manufacturerLine = lines.find(l => l.startsWith("Mfg id:"));
+                // DRM connector ends with the screen.name (e.g. "card0-DP-1" → "DP-1")
+                // — most reliable cross-reference back to a Quickshell ShellScreen.
+                const drmLine = lines.find(l => l.startsWith("DRM connector:") || l.startsWith("DRM_connector:"));
 
                 let model = "";
                 if (modelLine) {
@@ -127,17 +130,19 @@ Singleton {
                         model = `${manufacturer} ${model}`;
                 }
 
+                let drmConnector = "";
+                if (drmLine) {
+                    drmConnector = drmLine.split(":").slice(1).join(":").trim();
+                }
+
                 root.ddcMonitors.push({
                     model,
-                    busNum
+                    busNum,
+                    drmConnector
                 });
             }
         }
         onExited: root.ddcMonitorsChanged()
-    }
-
-    Process {
-        id: setProc
     }
 
     component BrightnessMonitor: QtObject {
@@ -157,6 +162,17 @@ Singleton {
                     usedBuses.push(mon.ddcEntry.busNum);
             }
 
+            // FIRST: try matching by DRM connector — most reliable cross-reference
+            // (e.g. screen.name = "DP-1" matches ddcEntry.drmConnector = "card0-DP-1")
+            const screenName = screen && screen.name ? screen.name : "";
+            if (screenName) {
+                const drmMatch = root.ddcMonitors.find(entry => entry.drmConnector && entry.drmConnector.endsWith(screenName) && !usedBuses.includes(entry.busNum));
+                if (drmMatch)
+                    return drmMatch;
+            }
+
+            // Fallback: match by model (may fail if Quickshell's screen.model
+            // strips the manufacturer prefix that ddcutil includes).
             const screenModel = screen && screen.model ? screen.model.toLowerCase() : "";
             if (screenModel) {
                 const modelMatch = root.ddcMonitors.find(entry => entry.model && entry.model.toLowerCase() === screenModel && !usedBuses.includes(entry.busNum));
@@ -164,6 +180,9 @@ Singleton {
                     return modelMatch;
             }
 
+            // Last resort: first unused bus (relies on stable screen-to-ddc order,
+            // which doesn't hold when Quickshell.screens enumerates monitors in a
+            // different order than ddcutil — that's the original cross-wired bug).
             for (let i = 0; i < root.ddcMonitors.length; ++i) {
                 const entry = root.ddcMonitors[i];
                 if (entry && entry.busNum && !usedBuses.includes(entry.busNum))
@@ -236,12 +255,18 @@ Singleton {
             }
         }
 
+        // Per-monitor setProc so concurrent setBrightness calls from different
+        // BrightnessMonitor instances don't race on a single shared Process (which
+        // would let the last-assigned command overwrite the first, causing one
+        // monitor's brightness change to never reach ddcutil).
+        readonly property Process setProc: Process {}
+
         function syncBrightness() {
             if (isDdc && !busNum)
                 return;
             const rounded = Math.round(monitor.brightness * monitor.rawMaxBrightness);
-            setProc.command = isDdc ? ["ddcutil", "-b", busNum, "setvcp", "10", rounded] : ["brightnessctl", "--class", "backlight", "s", rounded, "--quiet"];
-            setProc.startDetached();
+            monitor.setProc.command = isDdc ? ["ddcutil", "-b", busNum, "setvcp", "10", rounded] : ["brightnessctl", "--class", "backlight", "s", rounded, "--quiet"];
+            monitor.setProc.startDetached();
         }
 
         function setBrightness(value: real): void {


### PR DESCRIPTION
## Summary

Two related bugs that combined to make per-monitor brightness sliders unusable on multi-monitor setups where `Quickshell.screens` and `ddcutil detect` enumerate monitors in a different order.

### Bug 1 — shared `setProc` race

`setProc` was a single `Process` declared at the `Brightness` Singleton root, shared by every `BrightnessMonitor`. When two sliders fired `setBrightness` near-simultaneously, the second `setProc.command = …` overwrote the first before `startDetached()` had executed, so the first monitor's brightness change never reached `ddcutil`.

### Bug 2 — `ddcEntry` matching cross-wires sliders

The `ddcEntry` lookup tried `screen.model` first, then fell back to first-unused-bus order. Quickshell's `screen.model` can be the bare model name while `ddcutil` includes a manufacturer prefix (e.g. `H27T6` vs `SKG H27T6`), so the model match often fails. When `Quickshell.screens` enumerates monitors in a different order than `ddcutil detect`, the first-unused-bus fallback then assigns each `BrightnessMonitor` to the wrong DDC bus — slider for screen A controls bus B and vice versa.

## Changes

- **Per-monitor `setProc`** — each `BrightnessMonitor` now owns its own `Process` so concurrent slider changes don't overwrite each other's command.
- **DRM connector match** — `ddcutil detect --brief` already emits `DRM connector: card0-DP-1`; we now parse that into `entry.drmConnector` and match `entry.drmConnector.endsWith(screen.name)` as the primary lookup. This is the most reliable cross-reference back to a `ShellScreen` and avoids both the model-prefix mismatch and the screen-order fallback.
- Model match is kept as a secondary fallback, and the original first-unused-bus heuristic is kept as a last resort.

## Test plan

- [x] Dual-monitor setup (DP-1, DP-2) where Quickshell enumerates them in the opposite order to ddcutil. Each monitor's slider now controls its own monitor's brightness deterministically.
- [x] Drag both sliders simultaneously — both monitors receive their respective brightness updates (no more last-write-wins drop).

— robin