### PR TITLE
theme: add GTK3 selection colours so selected rows stay readable in Thunar etc

### DIFF
--- a/modules/theme/GtkGenerator.qml
+++ b/modules/theme/GtkGenerator.qml
@@ -36,12 +36,31 @@ QtObject {
         css += `@define-color card_bg_color ${surfaceContainer};\n`
         css += `@define-color card_fg_color ${onSurface};\n`
         
-        // Sidebar typically matches window or has slight contrast. 
+        // Sidebar typically matches window or has slight contrast.
         // Using window variables as reference.
         css += `@define-color sidebar_bg_color @window_bg_color;\n`
         css += `@define-color sidebar_fg_color @window_fg_color;\n`
         css += `@define-color sidebar_border_color @window_bg_color;\n`
         css += `@define-color sidebar_backdrop_color @window_bg_color;\n`
+
+        // GTK3 selection colours — without these, GTK3 apps (Thunar, etc) fall back to
+        // the theme's defaults which often leave selected rows with white text on the
+        // light accent colour (very low contrast). Map them to accent_bg/_fg so selected
+        // rows get the same dark-on-bright contrast that libadwaita uses for GTK4.
+        css += `@define-color theme_selected_bg_color @accent_bg_color;\n`
+        css += `@define-color theme_selected_fg_color @accent_fg_color;\n`
+        css += `@define-color theme_bg_color @window_bg_color;\n`
+        css += `@define-color theme_fg_color @window_fg_color;\n`
+        css += `@define-color theme_base_color @view_bg_color;\n`
+        css += `@define-color theme_text_color @view_fg_color;\n`
+
+        // Explicit selection styling override for views (file lists, tree views, etc)
+        // to force readable contrast regardless of theme defaults.
+        css += `\n`
+        css += `*:selected, *:selected:focus, row:selected, row:selected:focus {\n`
+        css += `    background-color: @accent_bg_color;\n`
+        css += `    color: @accent_fg_color;\n`
+        css += `}\n`
 
         const home = Quickshell.env("HOME")
         const gtk3Dir = home + "/.config/gtk-3.0"


### PR DESCRIPTION
## Summary

`GtkGenerator` writes only the libadwaita-flavoured colour variables (`accent_color`, `accent_fg_color`, `window_bg_color`, …). GTK3 apps like Thunar read a different set of names (`theme_selected_bg_color`, `theme_selected_fg_color`, `theme_bg_color`, `theme_fg_color`, `theme_base_color`, `theme_text_color`), so they fall back to whatever the underlying theme provides — on `adw-gtk3` dark that leaves selected rows with the global view foreground (near-white) painted on top of the matugen accent colour (often a light pastel). Result: barely-readable selected entries in file listings.

## Changes

`modules/theme/GtkGenerator.qml` (+20/-1):

- Map `theme_selected_bg_color` / `theme_selected_fg_color` to `accent_bg_color` / `accent_fg_color` so GTK3 selection inherits the same dark-on-bright contrast libadwaita uses for GTK4.
- Mirror `theme_bg_color` / `theme_fg_color` / `theme_base_color` / `theme_text_color` from the existing window/view variables for completeness.
- Add an explicit `*:selected, row:selected` override so the contrast holds even when the underlying theme has its own row-style.

No behaviour change for GTK4 / libadwaita consumers — they already pick up the `accent_*` family unchanged.

## Test plan

- [x] Open Thunar (GTK3) with a long file list, select a row — text is now readable on the matugen accent background instead of the near-white-on-pastel default.
- [x] Open a GTK4 / libadwaita app (Files, Settings) — selection still styled the same as before (accent_* unchanged).

— robin