### PR TITLE
feat(nix): add homeManagerModule for declarative settings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,9 @@
         programs.ambxst.package = lib.mkDefault self.packages.${pkgs.system}.default;
       };
 
-      homeManagerModules.default = { ... }: {
+      homeManagerModules.default = { pkgs, ... }: {
         imports = [ ./nix/modules/home.nix ];
+        _module.args.ambxstPackage = self.packages.${pkgs.system}.default;
       };
 
       packages = ambxstLib.forAllSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,10 @@
         programs.ambxst.package = lib.mkDefault self.packages.${pkgs.system}.default;
       };
 
+      homeManagerModules.default = { ... }: {
+        imports = [ ./nix/modules/home.nix ];
+      };
+
       packages = ambxstLib.forAllSystems (system:
         let
           pkgs = import nixpkgs {

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, ambxstPackage, ... }:
 
 let
   cfg = config.programs.ambxst;
@@ -47,7 +47,7 @@ in {
         text = builtins.toJSON value;
         onChange = ''
           if [ -f /tmp/ambxst.pid ] && kill -0 "$(cat /tmp/ambxst.pid 2>/dev/null)" 2>/dev/null; then
-            ambxst reload || true
+            ${lib.getExe ambxstPackage} reload || true
           fi
         '';
       }

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -47,7 +47,7 @@ in {
         text = builtins.toJSON value;
         onChange = ''
           if [ -f /tmp/ambxst.pid ] && kill -0 "$(cat /tmp/ambxst.pid 2>/dev/null)" 2>/dev/null; then
-            ambxst reload
+            ambxst reload || true
           fi
         '';
       }

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -42,9 +42,14 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.file = lib.mapAttrs' (name: value:
-      lib.nameValuePair ".config/ambxst/config/${name}.json" {
+    xdg.configFile = lib.mapAttrs' (name: value:
+      lib.nameValuePair "ambxst/config/${name}.json" {
         text = builtins.toJSON value;
+        onChange = ''
+          if [ -f /tmp/ambxst.pid ] && kill -0 "$(cat /tmp/ambxst.pid 2>/dev/null)" 2>/dev/null; then
+            ambxst reload
+          fi
+        '';
       }
     ) cfg.settings;
   };

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -45,11 +45,7 @@ in {
     xdg.configFile = lib.mapAttrs' (name: value:
       lib.nameValuePair "ambxst/config/${name}.json" {
         text = builtins.toJSON value;
-        onChange = ''
-          if [ -f /tmp/ambxst.pid ] && kill -0 "$(cat /tmp/ambxst.pid 2>/dev/null)" 2>/dev/null; then
-            ${lib.getExe ambxstPackage} reload || true
-          fi
-        '';
+        onChange = "${lib.getExe ambxstPackage} reload || true";
       }
     ) cfg.settings;
   };

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,0 +1,51 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.programs.ambxst;
+in {
+  options.programs.ambxst = {
+    enable = lib.mkEnableOption "Ambxst shell";
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          bar = {
+            position = "top";
+            use12hFormat = true;
+          };
+          theme = {
+            roundness = 8;
+            font = "Roboto";
+          };
+          compositor = {
+            gapsIn = 4;
+            blurEnabled = true;
+          };
+        }
+      '';
+      description = ''
+        Declarative Ambxst configuration. Each attribute name corresponds to a
+        configuration module and its value is written as JSON to
+        ''${XDG_CONFIG_HOME}/ambxst/config/<name>.json.
+
+        Available modules: bar, theme, system, compositor, performance,
+        weather, desktop, lockscreen, prefix, dock, ai, workspaces,
+        notch, overview.
+
+        Note: declared files are managed as read-only symlinks into the Nix
+        store. The GUI settings menu cannot persist changes to managed files.
+        Undeclared modules continue to use their GUI-editable defaults.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.file = lib.mapAttrs' (name: value:
+      lib.nameValuePair ".config/ambxst/config/${name}.json" {
+        text = builtins.toJSON value;
+      }
+    ) cfg.settings;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `homeManagerModules.default` flake output with a `programs.ambxst.settings` option
- Each attribute in `settings` maps to a JSON file at `$XDG_CONFIG_HOME/ambxst/config/<name>.json`
- Works with all config modules: `bar`, `theme`, `compositor`, `system`, `performance`, `weather`, `desktop`, `lockscreen`, `prefix`, `dock`, `ai`, `workspaces`, `notch`, `overview`

## Usage

Add the module to your Home Manager config:

```nix
# In your flake.nix
inputs.ambxst.url = "github:Axenide/Ambxst";

# In your home-manager config
{ inputs, ... }: {
  imports = [ inputs.ambxst.homeManagerModules.default ];

  programs.ambxst = {
    enable = true;
    settings = {
      bar = {
        position = "top";
        use12hFormat = true;
      };
      theme = {
        roundness = 8;
        font = "Roboto";
      };
      compositor = {
        gapsIn = 4;
        blurEnabled = true;
      };
    };
  };
}
```

## Notes

- Declared config files are managed as **read-only symlinks** into the Nix store. The GUI settings menu cannot persist changes to managed files — this is expected for declarative setups.
- Undeclared modules (e.g. `ai`, `weather`) are untouched and remain editable via the GUI.
- `builtins.toJSON` handles all JSON-compatible Nix values: nested attrsets, lists, strings, numbers, booleans, and null.

Closes #172