### PR TITLE
feat: generalize monitor wait and apply stability fixes

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -616,6 +616,22 @@ help | --help | -h)
 	show_help
 	;;
 "")
+	# Robust monitor-aware startup cleanup
+	pkill -f "qs -p .*shell.qml" 2>/dev/null || true
+	pkill -f "axctl.*daemon" 2>/dev/null || true
+	pkill -f "axctl subscribe" 2>/dev/null || true
+
+	# Wait for external monitor if physically connected (non-eDP, non-LVDS, non-Virtual, non-HEADLESS)
+	if hyprctl monitors all -j 2>/dev/null | jq -e '.[] | select(.name | test("^(eDP|LVDS|Virtual|HEADLESS)") | not)' >/dev/null 2>&1; then
+		for i in {1..50}; do
+			if hyprctl monitors -j 2>/dev/null | jq -e '.[] | select(.name | test("^(eDP|LVDS|Virtual|HEADLESS)") | not)' >/dev/null 2>&1; then
+				sleep 1.0
+				break
+			fi
+			sleep 0.2
+		done
+	fi
+
 	# Run daemon priority script (backgrounded to not block startup)
 	bash "${SCRIPT_DIR}/scripts/daemon_priority.sh" &
 

--- a/modules/lockscreen/LockScreen.qml
+++ b/modules/lockscreen/LockScreen.qml
@@ -35,9 +35,14 @@ WlSessionLockSurface {
         tintEnabled: GlobalStates.wallpaperManager ? GlobalStates.wallpaperManager.tintEnabled : false
 
         property string lockscreenFramePath: {
-            if (!GlobalStates.wallpaperManager)
+            if (!GlobalStates.wallpaperManager || !GlobalStates.wallpaperManager.currentWallpaper)
                 return "";
-            return GlobalStates.wallpaperManager.getLockscreenFramePath(GlobalStates.wallpaperManager.currentWallpaper);
+            try {
+                return GlobalStates.wallpaperManager.getLockscreenFramePath(GlobalStates.wallpaperManager.currentWallpaper);
+            } catch (e) {
+                console.warn("LockScreen: Failed to get lockscreen frame path:", e);
+                return "";
+            }
         }
 
         source: lockscreenFramePath ? "file://" + lockscreenFramePath : ""
@@ -84,7 +89,7 @@ WlSessionLockSurface {
     ScreencopyView {
         id: screencopyBackground
         anchors.fill: parent
-        captureSource: root.screen
+        captureSource: root.screen || null
         live: false
         paintCursor: false
         visible: startAnim  // Visible solo cuando startAnim es true
@@ -741,7 +746,9 @@ WlSessionLockSurface {
     // Initialize when component is created (when lock becomes active)
     Component.onCompleted: {
         // Capture screen immediately
-        screencopyBackground.captureFrame();
+        if (root.screen) {
+            screencopyBackground.captureFrame();
+        }
 
         // Start animations
         startAnim = true;

--- a/modules/widgets/dashboard/wallpapers/Wallpaper.qml
+++ b/modules/widgets/dashboard/wallpapers/Wallpaper.qml
@@ -682,6 +682,12 @@ PanelWindow {
         });
     }
 
+    Component.onDestruction: {
+        if (GlobalStates.wallpaperManager === wallpaper) {
+            GlobalStates.wallpaperManager = null;
+        }
+    }
+
     FileView {
         id: wallpaperConfig
         // QUICKSHELL-GIT: path: Quickshell.cachePath("wallpapers.json")


### PR DESCRIPTION
### Description

This PR introduces critical fixes for Ambxst shell startup synchronization, lockscreen stability, and resource cleanup.

#### 1. Generalizing `cli.sh` Startup Monitor Wait Loop
- **Problem**: When starting up or logging in with an external monitor plugged in, a race condition occurred between Kanshi's screen configuration and Ambxst's UI initialization. Ambxst would start drawing elements while monitor states were changing, causing partial UI load failures (missing bar, dock, etc.).
- **Fix**: Replaced the hardcoded monitor check with a dynamic wait loop using `hyprctl` and `jq`.
  - Scans `hyprctl monitors all -j` to detect if an external monitor (non-eDP, non-LVDS, non-Virtual, non-HEADLESS) is physically connected.
  - If connected, it waits (up to 10 seconds, in 0.2s increments) for the external monitor to become active (`disabled: false` in `hyprctl monitors -j`), sleeping for an additional 1.0s to let the layout settle.
  - If no external monitor is physically connected (e.g. laptop-on-the-go), the loop is skipped instantly, preventing boot delay.
  - Ensures a clean slate on startup by cleaning up early-start `quickshell` and `axctl` daemons.

#### 2. Enhancing `LockScreen.qml` Null Safety
- **Problem**: The session lockscreen would randomly crash when trying to capture a screenshot or retrieve the wallpaper frame path due to null properties.
- **Fix**:
  - Added null checks on `GlobalStates.wallpaperManager.currentWallpaper` before retrieving the frame path, wrapping it in a `try-catch` block.
  - Added null safety checks on `root.screen` for `screencopyBackground.captureSource` and guarded `screencopyBackground.captureFrame()` call.

#### 3. Fixing `Wallpaper.qml` Resource Cleanup
- **Problem**: Memory leaks or dangling references could occur when switching wallpapers or destroying wallpaper views.
- **Fix**: Added `Component.onDestruction` clean up to set `GlobalStates.wallpaperManager = null` when the component is destroyed.