### PR TITLE
fix: monitors transform

### DIFF
--- a/modules/services/AxctlService.qml
+++ b/modules/services/AxctlService.qml
@@ -141,6 +141,9 @@ Singleton {
                 height: mon.height,
                 refreshRate: mon.refresh_rate,
                 scale: mon.scale,
+                x: mon.metadata ? (parseInt(mon.metadata.x) || 0) : 0,
+                y: mon.metadata ? (parseInt(mon.metadata.y) || 0) : 0,
+                transform: mon.metadata ? (parseInt(mon.metadata.transform) || 0) : 0,
                 activeWorkspace: { id: parseInt(mon.metadata ? mon.metadata.active_workspace : 0) || 0, name: mon.metadata ? mon.metadata.active_workspace : "" }
             }));
             root.monitors.values = mappedMonitors;


### PR DESCRIPTION
## Describe your changes

Fix missing monitor position (`x`, `y`) and `transform` properties in the monitor objects sent to `axctl`. These values were already available in `mon.metadata` but were not being forwarded, causing the compositor to receive `undefined` for position and rotation of monitors.

This complements the earlier fix in 21bf99d4 ("Screenshot & Screenrecord tool now uses the right positions when monitors are transformed").

## Add screenshots

**Before — incorrect monitor positioning/disposition:**
<img width="2560" height="1080" alt="Before" src="https://github.com/user-attachments/assets/26afa447-af09-48bb-82d3-1296e926aa84" />

**After — monitors properly positioned with correct transform:**
<img width="2560" height="1080" alt="After" src="https://github.com/user-attachments/assets/8e37b43e-a962-42ee-b0b7-ef5bdf0e33dc" />

## Does this change any existing behavior?

Yes — monitors now report their correct `x`, `y`, and `transform` properties to `axctl`. Existing behavior is preserved for setups without transform metadata (`parseInt` falls back to `0`).